### PR TITLE
Changes for tracking improvements

### DIFF
--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/OSCEyeTracker.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/OSCEyeTracker.cs
@@ -16,14 +16,15 @@ namespace ASeeVROSCServer.ASeeVRInterface
         /// </summary>
         public OSCEyeTracker()
         {
-            _averageSteps = 6;
-            _movingAverageBufferSize = 10;
-            _movementMultiplierX = 1;
-            _movementMultiplierY = 1;
+            _averageSteps = 8;
+            _movingAverageBufferSize = 4;
+            _blinkTime = 6;
+            _movementMultiplierX = 1f;
+            _movementMultiplierY = 1f;
             _xLeftRange = new MinMaxRange(0, 1);
             _xRightRange = new MinMaxRange(0, 1);
             _yLeftRange = new MinMaxRange(0, 1);
-            _xRightRange = new MinMaxRange(0, 1);
+            _yRightRange = new MinMaxRange(0, 1);
         }
 
         #endregion
@@ -63,8 +64,23 @@ namespace ASeeVROSCServer.ASeeVRInterface
         /// <summary>
         /// Eye Tracking Multipliers.
         /// </summary>
-        public int _movementMultiplierX { get; private set; }
-        public int _movementMultiplierY { get; private set; }
+        public float _movementMultiplierX { get; private set; }
+        public float _movementMultiplierY { get; private set; }
+
+        /// <summary>
+        /// Step count for the rolling average
+        /// </summary>
+        public int _averageSteps;
+
+        /// <summary>
+        /// Frames ignored after losing tracking.
+        /// </summary>
+        public int _movingAverageBufferSize;
+
+        /// <summary>
+        /// Time to count full tracking loss as a blink.
+        /// </summary>
+        public int _blinkTime;
 
         #endregion
 
@@ -82,16 +98,6 @@ namespace ASeeVROSCServer.ASeeVRInterface
 
         #endregion
 
-        #region Private Properties
-
-        /// <summary>
-        /// Moving Average config.
-        /// </summary>
-        private int _averageSteps;
-        private int _movingAverageBufferSize;
-
-        #endregion
-
         #region Public Methods
 
         /// <summary>
@@ -105,8 +111,9 @@ namespace ASeeVROSCServer.ASeeVRInterface
             JsonElement root = doc.RootElement;
             _averageSteps = root.GetProperty("AverageSteps").GetInt32();
             _movingAverageBufferSize = root.GetProperty("MovingAverageBufferSize").GetInt32();
-            _movementMultiplierX = root.GetProperty("MovementMultiplierX").GetInt32();
-            _movementMultiplierY = root.GetProperty("MovementMultiplierY").GetInt32();
+            _blinkTime = root.GetProperty("BlinkTime").GetInt32();
+            _movementMultiplierX = (float)root.GetProperty("MovementMultiplierX").GetDouble();
+            _movementMultiplierY = (float)root.GetProperty("MovementMultiplierY").GetDouble();
             EyeXLeftAddress = root.GetProperty("EyeXLeftAddress").GetString();
             EyeXRightAddress = root.GetProperty("EyeXRightAddress").GetString();
             EyeYLeftAddress = root.GetProperty("EyeYLeftAddress").GetString();

--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/Utilites/MinMaxRange.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/Utilites/MinMaxRange.cs
@@ -27,8 +27,8 @@ namespace ASeeVROSCServer.ASeeVRInterface.Utilites
         /// </summary>
         public MinMaxRange(JsonElement root)
         {
-            Max = (float)root.GetProperty("Max").GetDecimal();
-            Min = (float)root.GetProperty("Min").GetDecimal();
+            Max = (float)root.GetProperty("Max").GetDouble();
+            Min = (float)root.GetProperty("Min").GetDouble();
         }
     }
 }

--- a/ASeeVROSCServer/ASeeVROSCServer/Program.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/Program.cs
@@ -21,7 +21,7 @@ namespace ASeeVROSCServer
 
             Console.WriteLine(System.IO.Directory.GetCurrentDirectory());
             ConfigData = new OSCEyeTracker();
-            ConfigData.InitializeTrackingParams("config.json");
+            ConfigData.InitializeTrackingParams("Config.json");
 
 
             eyeTracker = new EyeTracker();
@@ -42,7 +42,7 @@ namespace ASeeVROSCServer
 
         private static void Runner()
         {
-            dataHandler = new ASeeVRDataHandler(eyeTracker, sender, 6, ConfigData);
+            dataHandler = new ASeeVRDataHandler(eyeTracker, sender, ConfigData);
             while (true)
             {
                 if (!runThread) break;

--- a/ASeeVROSCServer/ASeeVROSCServer/README.txt
+++ b/ASeeVROSCServer/ASeeVROSCServer/README.txt
@@ -3,14 +3,17 @@
 Address Parameters should match the parameters on your avatar prefixed by "/avatar/parameters/", example config should work for 
 	VRCFT configured avatars.
 
-The Average steps config value determines how many frame iterations are kept in the average.  This affects smoothing, a higher
-	value will make the tracking less susceptible to bad data or noise but slower to track the eye between 2 and 20 seems to be
-	a good range
+The AverageSteps config value determines how many frame iterations are kept in the average.  This affects smoothing, a higher
+	value will make the tracking less susceptible to bad data or noise but slower to track the eye. Between 2 and 20 is a good
+	good range
 
-The moving average buffer size config value determines how many good frames are required to pass tracking data as valid.  As an
-	example: It defaults to 10 this means that if there is a bad frame, for the next 10 frames it will be treated as not tracking
+The MovingAverageBufferSize config value determines how many good frames are required to pass tracking data as valid.  As an
+	example: It defaults to 4 this means that if there is a bad frame, for the next 4 frames it will be treated as not tracking
 	the eye.  The purpose of this value to filter out situations where the eye tracker loses tracking and starts creating false 
-	tracks, as these false tracks tend to not be consistent tracking blocks.  Good values are between 0 and 50.
+	tracks, as these false tracks tend to not be consistent tracking blocks.  Good values are between 0 and 40.
+
+The BlinkTime config value determines how many frames your eyes need to be closed before it considers them as closed. Defaults
+	to 4. Good values are between 0 and 100.
 
 
 There are two methods for configuring normalization:
@@ -29,4 +32,3 @@ The next plans for this application are to implement a UI and wizard that allows
 Note: for those who are more programming savvy, included with the project is an implementation of the 1Euro eye tracking smoothing
 	algorithm.  I haven't done testing to detemine if it is more effective than a simple moving average as I have implemented. If
 	you decide to test it out and find it preferable please let me know!
-

--- a/ASeeVROSCServer/Config.json
+++ b/ASeeVROSCServer/Config.json
@@ -1,34 +1,30 @@
-{	
-	"AverageSteps" : 6,
-	"MovingAverageBufferSize" : 10,
-	"MovementMultiplierX" : 2,
-	"MovementMultiplierY" : 10,
-	"EyeXLeftAddress" : "/avatar/parameters/LeftEyeX",
-    "EyeXRightAddress" : "/avatar/parameters/RightEyeX",
-    "EyeYAddress" : "/avatar/parameters/EyesY",
-	"EyeYLeftAddress" : "/avatar/parameters/LeftEyeY",
-	"EyeYRightAddress" : "/avatar/parameters/RightEyeY",
-    "EyeLidLeftAddress" : "/avatar/parameters/LeftEyeLid",
-    "EyeLidRightAddress" : "/avatar/parameters/RightEyeLid",
-	"xLeftRange" : 
-	{
-		"Max" : 1.0,
-		"Min" : 0.0
-	},
-	"xRightRange" : 
-	{
-		"Max" : 1.0,
-		"Min" : 0.0
-	},
-	"yLeftRange" : 
-	{
-		"Max" : 1.0,
-		"Min" : 0.0
-	},
-	"yRightRange" : 
-	{
-		"Max" : 1.0,
-		"Min" : 0.0
-	}
+{
+  "AverageSteps": 8,
+  "MovingAverageBufferSize": 4,
+  "BlinkTime": 4,
+  "MovementMultiplierX": 1.0,
+  "MovementMultiplierY": 1.0,
+  "EyeXLeftAddress": "/avatar/parameters/LeftEyeX",
+  "EyeXRightAddress": "/avatar/parameters/RightEyeX",
+  "EyeYAddress": "/avatar/parameters/EyesY",
+  "EyeYLeftAddress": "/avatar/parameters/LeftEyeY",
+  "EyeYRightAddress": "/avatar/parameters/RightEyeY",
+  "EyeLidLeftAddress": "/avatar/parameters/LeftEyeLid",
+  "EyeLidRightAddress": "/avatar/parameters/RightEyeLid",
+  "xLeftRange": {
+    "Max": 1.0,
+    "Min": 0.0
+  },
+  "xRightRange": {
+    "Max": 1.0,
+    "Min": 0.0
+  },
+  "yLeftRange": {
+    "Max": 1.0,
+    "Min": 0.0
+  },
+  "yRightRange": {
+    "Max": 1.0,
+    "Min": 0.0
+  }
 }
-


### PR DESCRIPTION
- Implemented the buffer thing (when losing tracking, don't track the eye for the future x frames)
- Implented a configurable BlinkTimer (need both eyes to be closed for x frames to consider them as blinking)
During those x frames, the eyes will use the last good position instead of the other eye (who also lost tracking).
- Made the x and y multipliers floats (instead of ints)
- Fix the eyes vertical movement (+ instead of *)
- Changed some default values Config.json