### PR TITLE
Better blink + wink (with its own timer)

### DIFF
--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
@@ -66,7 +66,8 @@ namespace ASeeVROSCServer.ASeeVRInterface
         /// Timers
         /// </summary>
         /// integers incrementing each frames under certain conditions to time stuff.
-        float blinkTimer, trackingLossTimerLeft, trackingLossTimerRight;
+        int blinkTimerCombined, blinkTimerLeft, blinkTimerRight;
+        int trackingLossTimerLeft, trackingLossTimerRight;
 
         #endregion
 
@@ -104,7 +105,6 @@ namespace ASeeVROSCServer.ASeeVRInterface
                 _eyeTracker.RightEye.Eye,
                 EyeExpression.Blink
             );
-
 
             // Check if the eyes lost tracking
             bool lostTrackingLeft = x_Left == 0;
@@ -188,11 +188,50 @@ namespace ASeeVROSCServer.ASeeVRInterface
             // Handle blinking
             if (blink_Left == 1 && blink_Right == 1)
             {
-                blinkTimer++;
-                if (blinkTimer >= ConfigData._blinkTime)
+                blinkTimerCombined++;
+                blinkTimerLeft++;
+                blinkTimerRight++;
+                if (blinkTimerCombined >= ConfigData._blinkTime)
                 {
                     messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
                     messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
+                }
+                else if (blink_Left == 1 || blink_Right == 1)
+                {
+                    if (blink_Left == 1)
+                    {
+                        blinkTimerLeft++;
+                        if (blinkTimerLeft >= ConfigData._winkTime)
+                        {
+                            messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
+                        }
+                        else
+                        {
+                            messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                        }
+                    }
+                    else
+                    {
+                        blinkTimerLeft = 0;
+                        messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                    }
+                    if (blink_Right == 1)
+                    {
+                        blinkTimerRight++;
+                        if (blinkTimerRight >= ConfigData._winkTime)
+                        {
+                            messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
+                        }
+                        else
+                        {
+                            messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                        }
+                    }
+                    else
+                    {
+                        blinkTimerRight = 0;
+                        messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                    }
                 }
                 else
                 {
@@ -200,9 +239,49 @@ namespace ASeeVROSCServer.ASeeVRInterface
                     messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
                 }
             }
+            else if (blink_Left == 1 || blink_Right == 1)
+            {
+                blinkTimerCombined = 0;
+                if (blink_Left == 1)
+                {
+                    blinkTimerLeft++;
+                    if (blinkTimerLeft >= ConfigData._winkTime)
+                    {
+                        messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
+                    }
+                    else
+                    {
+                        messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                    }
+                }
+                else
+                {
+                    blinkTimerLeft = 0;
+                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                }
+                if (blink_Right == 1)
+                {
+                    blinkTimerRight++;
+                    if (blinkTimerRight >= ConfigData._winkTime)
+                    {
+                        messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
+                    }
+                    else
+                    {
+                        messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                    }
+                }
+                else
+                {
+                    blinkTimerRight = 0;
+                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                }
+            }
             else
             {
-                blinkTimer = 0;
+                blinkTimerCombined = 0;
+                blinkTimerLeft = 0;
+                blinkTimerRight = 0;
                 messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
                 messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
             }

--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
@@ -106,6 +106,7 @@ namespace ASeeVROSCServer.ASeeVRInterface
                 EyeExpression.Blink
             );
 
+            #region Tracking loss
             // Check if the eyes lost tracking
             bool lostTrackingLeft = x_Left == 0;
             bool lostTrackingRight = x_Right == 0;
@@ -184,107 +185,61 @@ namespace ASeeVROSCServer.ASeeVRInterface
                     lastGoodRightY = y_Right;
                 }
             }
+            #endregion
 
-            // Handle blinking
+            #region Handle blinking
+            int lidLeft = 1, lidRight = 1;
             if (blink_Left == 1 && blink_Right == 1)
             {
                 blinkTimerCombined++;
                 blinkTimerLeft++;
                 blinkTimerRight++;
+
                 if (blinkTimerCombined >= ConfigData._blinkTime)
                 {
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
-                }
-                else if (blink_Left == 1 || blink_Right == 1)
-                {
-                    if (blink_Left == 1)
-                    {
-                        blinkTimerLeft++;
-                        if (blinkTimerLeft >= ConfigData._winkTime)
-                        {
-                            messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
-                        }
-                        else
-                        {
-                            messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
-                        }
-                    }
-                    else
-                    {
-                        blinkTimerLeft = 0;
-                        messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
-                    }
-                    if (blink_Right == 1)
-                    {
-                        blinkTimerRight++;
-                        if (blinkTimerRight >= ConfigData._winkTime)
-                        {
-                            messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
-                        }
-                        else
-                        {
-                            messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
-                        }
-                    }
-                    else
-                    {
-                        blinkTimerRight = 0;
-                        messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
-                    }
-                }
-                else
-                {
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                    lidLeft = 0;
+                    lidRight = 0;
                 }
             }
-            else if (blink_Left == 1 || blink_Right == 1)
+            if (blink_Left == 1 || blink_Right == 1)
             {
-                blinkTimerCombined = 0;
                 if (blink_Left == 1)
                 {
                     blinkTimerLeft++;
+
                     if (blinkTimerLeft >= ConfigData._winkTime)
                     {
-                        messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
-                    }
-                    else
-                    {
-                        messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                        lidLeft = 0;
                     }
                 }
                 else
                 {
                     blinkTimerLeft = 0;
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
                 }
                 if (blink_Right == 1)
                 {
                     blinkTimerRight++;
+
                     if (blinkTimerRight >= ConfigData._winkTime)
                     {
-                        messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
-                    }
-                    else
-                    {
-                        messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                        lidRight = 0;
                     }
                 }
                 else
                 {
                     blinkTimerRight = 0;
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
                 }
             }
-            else
+            if (blink_Left == 0 && blink_Right == 0)
             {
                 blinkTimerCombined = 0;
                 blinkTimerLeft = 0;
                 blinkTimerRight = 0;
-                messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
-                messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
             }
+
+            messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, lidLeft));
+            messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, lidRight));
+            #endregion
 
             // Add the new values to the moving average
             x_Left = ConfigData.MovingAverageLeftX.Update(x_Left);

--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
@@ -79,7 +79,7 @@ namespace ASeeVROSCServer.ASeeVRInterface
         {
             Queue<OscMessage> messages = new Queue<OscMessage>();
 
-            // Get the eyes' positions
+            // Get the eyes' components
             float x_Left = _eyeTracker.GetEyeParameter(
                 _eyeTracker.LeftEye.Eye,
                 EyeParameter.PupilCenterX
@@ -96,34 +96,21 @@ namespace ASeeVROSCServer.ASeeVRInterface
                 _eyeTracker.RightEye.Eye,
                 EyeParameter.PupilCenterY
             );
+            float blink_Left = _eyeTracker.GetEyeExpression(
+                _eyeTracker.LeftEye.Eye,
+                EyeExpression.Blink
+            );
+            float blink_Right = _eyeTracker.GetEyeExpression(
+                _eyeTracker.RightEye.Eye,
+                EyeExpression.Blink
+            );
+
 
             // Check if the eyes lost tracking
             bool lostTrackingLeft = x_Left == 0;
             bool lostTrackingRight = x_Right == 0;
 
-            // Blinking
-            if (lostTrackingLeft && lostTrackingRight)
-            {
-                blinkTimer++;
-                if (blinkTimer >= ConfigData._blinkTime)
-                {
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
-                }
-                else
-                {
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
-                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
-                }
-            }
-            else
-            {
-                blinkTimer = 0;
-                messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
-                messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
-            }
-
-            // Eye positions when losing tracking
+            // Handle eyes when losing tracking
             if (lostTrackingLeft)
             {
                 trackingLossTimerLeft = 0;
@@ -196,6 +183,28 @@ namespace ASeeVROSCServer.ASeeVRInterface
                     lastGoodRightX = x_Right;
                     lastGoodRightY = y_Right;
                 }
+            }
+
+            // Handle blinking
+            if (blink_Left == 1 && blink_Right == 1)
+            {
+                blinkTimer++;
+                if (blinkTimer >= ConfigData._blinkTime)
+                {
+                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 0));
+                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 0));
+                }
+                else
+                {
+                    messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                    messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
+                }
+            }
+            else
+            {
+                blinkTimer = 0;
+                messages.Enqueue(new OscMessage(ConfigData.EyeLidLeftAddress, 1));
+                messages.Enqueue(new OscMessage(ConfigData.EyeLidRightAddress, 1));
             }
 
             // Add the new values to the moving average

--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/OSCEyeTracker.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/OSCEyeTracker.cs
@@ -16,9 +16,10 @@ namespace ASeeVROSCServer.ASeeVRInterface
         /// </summary>
         public OSCEyeTracker()
         {
-            _averageSteps = 8;
+            _averageSteps = 10;
             _movingAverageBufferSize = 4;
-            _blinkTime = 6;
+            _blinkTime = 2;
+            _winkTime = 6;
             _movementMultiplierX = 1f;
             _movementMultiplierY = 1f;
             _xLeftRange = new MinMaxRange(0, 1);
@@ -78,9 +79,14 @@ namespace ASeeVROSCServer.ASeeVRInterface
         public int _movingAverageBufferSize;
 
         /// <summary>
-        /// Time to count full tracking loss as a blink.
+        /// Frames required to pass blinking as an actual blink.
         /// </summary>
         public int _blinkTime;
+
+        /// <summary>
+        /// Time to pass individual eye blinking as a wink
+        /// </summary>
+        public int _winkTime;
 
         #endregion
 
@@ -112,6 +118,7 @@ namespace ASeeVROSCServer.ASeeVRInterface
             _averageSteps = root.GetProperty("AverageSteps").GetInt32();
             _movingAverageBufferSize = root.GetProperty("MovingAverageBufferSize").GetInt32();
             _blinkTime = root.GetProperty("BlinkTime").GetInt32();
+            _winkTime = root.GetProperty("WinkTime").GetInt32();
             _movementMultiplierX = (float)root.GetProperty("MovementMultiplierX").GetDouble();
             _movementMultiplierY = (float)root.GetProperty("MovementMultiplierY").GetDouble();
             EyeXLeftAddress = root.GetProperty("EyeXLeftAddress").GetString();

--- a/ASeeVROSCServer/ASeeVROSCServer/README.txt
+++ b/ASeeVROSCServer/ASeeVROSCServer/README.txt
@@ -15,6 +15,10 @@ The MovingAverageBufferSize config value determines how many good frames are req
 The BlinkTime config value determines how many frames your eyes need to be closed before it considers them as closed. Will avoid
 	your eyes closing when losing tracking with higher values but have a harder time detect your blinks. Defaults to 2. 
 	Good values are between 0 and 30.
+	
+The WinkTime config value determines how many frames one of your eye need to be closed before it considers it as closed.
+	Will greatly avoid your eyes closing when losing tracking with higher values but have a harder time detect your winks. 
+	Defaults to 50. Good values are between 2 and 100.
 
 
 There are two methods for configuring normalization:

--- a/ASeeVROSCServer/ASeeVROSCServer/README.txt
+++ b/ASeeVROSCServer/ASeeVROSCServer/README.txt
@@ -4,16 +4,17 @@ Address Parameters should match the parameters on your avatar prefixed by "/avat
 	VRCFT configured avatars.
 
 The AverageSteps config value determines how many frame iterations are kept in the average.  This affects smoothing, a higher
-	value will make the tracking less susceptible to bad data or noise but slower to track the eye. Between 2 and 20 is a good
-	good range
+	value will make the tracking less susceptible to bad data or noise but slower to track the eye. Defaults to 10.
+	Good values are between 2 and 20.
 
 The MovingAverageBufferSize config value determines how many good frames are required to pass tracking data as valid.  As an
 	example: It defaults to 4 this means that if there is a bad frame, for the next 4 frames it will be treated as not tracking
 	the eye.  The purpose of this value to filter out situations where the eye tracker loses tracking and starts creating false 
 	tracks, as these false tracks tend to not be consistent tracking blocks.  Good values are between 0 and 40.
 
-The BlinkTime config value determines how many frames your eyes need to be closed before it considers them as closed. Defaults
-	to 4. Good values are between 0 and 100.
+The BlinkTime config value determines how many frames your eyes need to be closed before it considers them as closed. Will avoid
+	your eyes closing when losing tracking with higher values but have a harder time detect your blinks. Defaults to 2. 
+	Good values are between 0 and 30.
 
 
 There are two methods for configuring normalization:

--- a/ASeeVROSCServer/ASeeVROSCServer/README.txt
+++ b/ASeeVROSCServer/ASeeVROSCServer/README.txt
@@ -18,7 +18,7 @@ The BlinkTime config value determines how many frames your eyes need to be close
 	
 The WinkTime config value determines how many frames one of your eye need to be closed before it considers it as closed.
 	Will greatly avoid your eyes closing when losing tracking with higher values but have a harder time detect your winks. 
-	Defaults to 50. Good values are between 2 and 100.
+	Defaults to 200. Good values are between 2 and 10000 (to disable winking).
 
 
 There are two methods for configuring normalization:

--- a/ASeeVROSCServer/Config.json
+++ b/ASeeVROSCServer/Config.json
@@ -2,7 +2,7 @@
   "AverageSteps": 10,
   "MovingAverageBufferSize": 4,
   "BlinkTime": 2,
-  "WinkTime": 50,
+  "WinkTime": 200,
   "MovementMultiplierX": 1.0,
   "MovementMultiplierY": 1.0,
   "EyeXLeftAddress": "/avatar/parameters/LeftEyeX",

--- a/ASeeVROSCServer/Config.json
+++ b/ASeeVROSCServer/Config.json
@@ -1,7 +1,7 @@
 {
-  "AverageSteps": 8,
+  "AverageSteps": 10,
   "MovingAverageBufferSize": 4,
-  "BlinkTime": 4,
+  "BlinkTime": 2,
   "MovementMultiplierX": 1.0,
   "MovementMultiplierY": 1.0,
   "EyeXLeftAddress": "/avatar/parameters/LeftEyeX",

--- a/ASeeVROSCServer/Config.json
+++ b/ASeeVROSCServer/Config.json
@@ -2,6 +2,7 @@
   "AverageSteps": 10,
   "MovingAverageBufferSize": 4,
   "BlinkTime": 2,
+  "WinkTime": 50,
   "MovementMultiplierX": 1.0,
   "MovementMultiplierY": 1.0,
   "EyeXLeftAddress": "/avatar/parameters/LeftEyeX",


### PR DESCRIPTION
*Damnit I wanted to add this to my other PR but am ~~15~~ 60 minutes too late ;-;*
- Use expressions for blinking instead of tracking loss. This seems to work much better and has less accidental blinking.
- Add individual eye closing (winking). WinkTime decides how long an individual eye needs to be closed for it to be considered closed and not noise. Defaults to 50 to avoid unwanted eye closing, put to an arbitrary high value to disable winking (e.g: 10000).