### PR TITLE
Implement basic calibration

### DIFF
--- a/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/ASeeVRInterface/ASeeVRDataHandler.cs
@@ -69,6 +69,11 @@ namespace ASeeVROSCServer.ASeeVRInterface
         int blinkTimerCombined, blinkTimerLeft, blinkTimerRight;
         int trackingLossTimerLeft, trackingLossTimerRight;
 
+        /// <summary>
+        /// Calibration offsets
+        /// </summary>
+        float offsetLeftX, offsetLeftY, offsetRightX, offsetRightY;
+
         #endregion
 
         #region Public Methods
@@ -110,6 +115,11 @@ namespace ASeeVROSCServer.ASeeVRInterface
             // Check if the eyes lost tracking
             bool lostTrackingLeft = x_Left == 0;
             bool lostTrackingRight = x_Right == 0;
+
+            x_Left += offsetLeftX;
+            x_Right += offsetRightX;
+            y_Left += offsetLeftY;
+            y_Right += offsetRightY;
 
             // Handle eyes when losing tracking
             if (lostTrackingLeft)
@@ -259,6 +269,38 @@ namespace ASeeVROSCServer.ASeeVRInterface
             messages.Enqueue(new OscMessage(ConfigData.EyeYAddress, -(y_Left + y_Right / 2) * ConfigData._movementMultiplierY));
 
             SendMessages(messages);
+        }
+
+        /// <summary>
+        /// Calculates the eye offsets from 0
+        /// </summary>
+        public void Calibrate()
+        {
+            // Get the eyes' components
+            float x_Left = _eyeTracker.GetEyeParameter(
+                _eyeTracker.LeftEye.Eye,
+                EyeParameter.PupilCenterX
+            );
+            float x_Right = _eyeTracker.GetEyeParameter(
+                _eyeTracker.RightEye.Eye,
+                EyeParameter.PupilCenterX
+            );
+            float y_Left = _eyeTracker.GetEyeParameter(
+                _eyeTracker.LeftEye.Eye,
+                EyeParameter.PupilCenterY
+            );
+            float y_Right = _eyeTracker.GetEyeParameter(
+                _eyeTracker.RightEye.Eye,
+                EyeParameter.PupilCenterY
+            );
+            
+            // assigns offsets
+            offsetLeftX = 0.5f - x_Left;
+            offsetRightX = 0.5f - x_Right;
+            offsetLeftY = 0.5f - y_Left;
+            offsetRightY = 0.5f - y_Right;
+
+            Console.WriteLine(" Calibrated successfully!");
         }
 
         #endregion

--- a/ASeeVROSCServer/ASeeVROSCServer/Program.cs
+++ b/ASeeVROSCServer/ASeeVROSCServer/Program.cs
@@ -12,7 +12,7 @@ namespace ASeeVROSCServer
         static ASeeVRDataHandler dataHandler;
         static SharpOSC.UDPSender sender;
         static EyeTracker eyeTracker;
-        static bool runThread;
+        static bool runThread, calibrate;
         static OSCEyeTracker ConfigData;
 
         static void Main(string[] args)
@@ -33,11 +33,21 @@ namespace ASeeVROSCServer
             thr.Start();
 
             Thread.Sleep(500);
-            Console.Write("Press any key to stop...\n");
+            Console.Write("Press S to stop or C to calibrate...\n");
 
-            Console.ReadKey();
-            runThread = false;
-            eyeTracker.Stop();
+            while (true)
+            {
+                ConsoleKeyInfo input = Console.ReadKey();
+                if (input.KeyChar == char.Parse("s"))
+                {
+                    runThread = false;
+                    eyeTracker.Stop();
+                }
+                else if (input.KeyChar == char.Parse("c"))
+                {
+                    calibrate = true;
+                }
+            }
         }
 
         private static void Runner()
@@ -46,9 +56,14 @@ namespace ASeeVROSCServer
             while (true)
             {
                 if (!runThread) break;
-                Thread.Sleep(1000);
+                if (calibrate)
+                {
+                    calibrate = false;
+                    dataHandler.Calibrate();
+                }
+                Thread.Sleep(500);
             }
-            Console.WriteLine("Stopped");
+            Console.WriteLine(" Stopped successfully.");
         }
     }
 }


### PR DESCRIPTION
Guppy is still working on making the calibration data useable, so, currently, the eyes are indeed not calibrated (I was surprised to learn this!).

This implements a simple calibration to find the offset from the center (looking forward),

Seems to mostly (if not completely) solve the eye jumping problem too! (Altho the jump was already smoothed since my second PR so it wasn't that bad anymore anyway).